### PR TITLE
Namespace tags derived from top level metrics fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,25 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.rackspace.salus</groupId>
+      <artifactId>salus-telemetry-model</artifactId>
+      <version>0.1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>spring-boot-starter-data-jpa</artifactId>
+          <groupId>org.springframework.boot</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>hibernate-jpamodelgen</artifactId>
+          <groupId>org.hibernate</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>salus-common</artifactId>
+          <groupId>com.rackspace.salus</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/com/rackspace/salus/event/common/Tags.java
+++ b/src/main/java/com/rackspace/salus/event/common/Tags.java
@@ -27,7 +27,7 @@ public class Tags {
   public static final String RESOURCE_ID = qualify("resourceId");
   public static final String RESOURCE_LABEL = qualify("resourceLabel");
   public static final String MONITORING_SYSTEM = qualify("monitoringSystem");
-  public static final String TENANT = qualify("tenant");
+  public static final String QUALIFIED_ACCOUNT = qualify("qualifiedAccount");
 
   private static String qualify(String resourceId) {
     return applyNamespace(EVENT_ENGINE_TAGS, resourceId);

--- a/src/main/java/com/rackspace/salus/event/common/Tags.java
+++ b/src/main/java/com/rackspace/salus/event/common/Tags.java
@@ -16,14 +16,22 @@
 
 package com.rackspace.salus.event.common;
 
+import static com.rackspace.salus.telemetry.model.LabelNamespaces.EVENT_ENGINE_TAGS;
+import static com.rackspace.salus.telemetry.model.LabelNamespaces.applyNamespace;
+
 /**
  * Contains common tags applied to metrics sent to kapacitor. Kapacitor and the others in the
  * TICK stack use the term "tag", which is equivalent to our use of the term "label".
  */
 public class Tags {
-  public static final String RESOURCE_ID = "resourceId";
-  public static final String ACCOUNT = "account";
-  public static final String ACCOUNT_TYPE = "accountType";
-  public static final String RESOURCE_LABEL = "resourceLabel";
-  public static final String MONITORING_SYSTEM = "monitoringSystem";
+  public static final String RESOURCE_ID = qualify("resourceId");
+  public static final String RESOURCE_LABEL = qualify("resourceLabel");
+  public static final String MONITORING_SYSTEM = qualify("monitoringSystem");
+  public static final String TENANT = qualify("tenant");
+
+  private static String qualify(String resourceId) {
+    return applyNamespace(EVENT_ENGINE_TAGS, resourceId);
+  }
+
+  private Tags() {}
 }

--- a/src/test/java/com/rackspace/salus/event/common/TagsTest.java
+++ b/src/test/java/com/rackspace/salus/event/common/TagsTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.common;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import com.rackspace.salus.telemetry.model.LabelNamespaces;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TagsTest {
+
+  @Parameters
+  public static Collection<String> namespaces() {
+    return Arrays.asList(
+        Tags.MONITORING_SYSTEM,
+        Tags.RESOURCE_ID,
+        Tags.RESOURCE_LABEL,
+        Tags.TENANT
+    );
+  }
+
+  final String tag;
+
+  public TagsTest(String tag) {
+    this.tag = tag;
+  }
+
+  @Test
+  public void testTagIsNamespaced() {
+    assertThat(
+        tag.contains(LabelNamespaces.EVENT_ENGINE_TAGS),
+        is(true)
+    );
+  }
+}

--- a/src/test/java/com/rackspace/salus/event/common/TagsTest.java
+++ b/src/test/java/com/rackspace/salus/event/common/TagsTest.java
@@ -20,8 +20,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 import com.rackspace.salus.telemetry.model.LabelNamespaces;
-import java.util.Arrays;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -32,12 +34,17 @@ public class TagsTest {
 
   @Parameters
   public static Collection<String> namespaces() {
-    return Arrays.asList(
-        Tags.MONITORING_SYSTEM,
-        Tags.RESOURCE_ID,
-        Tags.RESOURCE_LABEL,
-        Tags.TENANT
-    );
+    final List<String> namespaces = new ArrayList<>();
+
+    for (Field field : Tags.class.getDeclaredFields()) {
+      try {
+        namespaces.add((String) field.get(Tags.class));
+      } catch (IllegalAccessException e) {
+        throw new IllegalStateException(e);
+      }
+    }
+
+    return namespaces;
   }
 
   final String tag;


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-262

# What

Since the top level metric fields have deterministic meaning for the downstream systems, we need to namespace those in contrast to the potentially user and agent provided label/tags.

# How

Uses the `LabelNamespaces` from the model module.

## How to test

Added a unit test where I was playing with my new discovery of https://github.com/junit-team/junit4/wiki/parameterized-tests