### PR TITLE
Use snakecase for the common tags to align with underscore delimiters

### DIFF
--- a/src/main/java/com/rackspace/salus/event/common/Tags.java
+++ b/src/main/java/com/rackspace/salus/event/common/Tags.java
@@ -24,10 +24,10 @@ import static com.rackspace.salus.telemetry.model.LabelNamespaces.applyNamespace
  * TICK stack use the term "tag", which is equivalent to our use of the term "label".
  */
 public class Tags {
-  public static final String RESOURCE_ID = qualify("resourceId");
-  public static final String RESOURCE_LABEL = qualify("resourceLabel");
-  public static final String MONITORING_SYSTEM = qualify("monitoringSystem");
-  public static final String QUALIFIED_ACCOUNT = qualify("qualifiedAccount");
+  public static final String RESOURCE_ID = qualify("resource_id");
+  public static final String RESOURCE_LABEL = qualify("resource_label");
+  public static final String MONITORING_SYSTEM = qualify("monitoring_system");
+  public static final String QUALIFIED_ACCOUNT = qualify("qualified_account");
 
   private static String qualify(String resourceId) {
     return applyNamespace(EVENT_ENGINE_TAGS, resourceId);


### PR DESCRIPTION
# What

Looking at all of the tags together when populated by event-engine-ingest, the common tags prefixed by "system_" looked odd when they were camelcase:

```
Point [name=procstat_lookup, time=1557866960000, tags={agent_discovered_arch=amd64, agent_discovered_hostname=MS90HCG8WL, agent_discovered_os=darwin, agent_environment=localdev, pattern=java, pingable=false, resource_metadata_envoyId=c800fb1c-7681-11e9-a11a-6a00027f65d0, system_monitoringSystem=SALUS, system_qualifiedAccount=RCN:aaaaaa, system_resourceId=development:0}, precision=MILLISECONDS, fields={pid_count=9.0}]
```

# How

Use snakecase for the common tags, so they align with the use of underscore for the label namespace delimiter.

## How to test

Existing unit tests