### PR TITLE
Fixed the missing user.home volume in cloudbuild-deploy.yaml

### DIFF
--- a/cloudbuild-deploy.yaml
+++ b/cloudbuild-deploy.yaml
@@ -23,6 +23,9 @@ steps:
         gsutil cp gs://${_GCS_CACHE_BUCKET}/${_SALUS_PROJECT}-m2-cache.tar.gz /tmp/m2-cache.tar.gz &&
         tar -xzf /tmp/m2-cache.tar.gz
       ) || echo 'Cache not found'
+    volumes:
+    - name: user.home
+      path: /root
 
   - id: DEPLOY
     name: 'gcr.io/cloud-builders/mvn'


### PR DESCRIPTION
# Resolves
The PULL_DOWN_CACHE stage was missing the volume that holds the .m2 directory.