### PR TITLE
Qualify k8s kapacitor hostname by its service name

### DIFF
--- a/src/main/java/com/rackspace/salus/event/discovery/KubernetesServiceEndpointPicker.java
+++ b/src/main/java/com/rackspace/salus/event/discovery/KubernetesServiceEndpointPicker.java
@@ -165,7 +165,7 @@ public class KubernetesServiceEndpointPicker extends EventEnginePicker implement
 
             engineInstances.add(
                 new EngineInstance(
-                    endpointAddress.getHostname(),
+                    String.join(".", endpointAddress.getHostname(), properties.getServiceName()),
                     port,
                     engineInstances.size()
                 )

--- a/src/test/java/com/rackspace/salus/event/discovery/KubernetesServiceEndpointPickerTest.java
+++ b/src/test/java/com/rackspace/salus/event/discovery/KubernetesServiceEndpointPickerTest.java
@@ -72,11 +72,11 @@ public class KubernetesServiceEndpointPickerTest {
         allInstances,
         contains(
             allOf(
-                hasProperty("host", equalTo("kapacitor-0")),
+                hasProperty("host", equalTo("kapacitor-0.kapacitor")),
                 hasProperty("port", equalTo(9092))
             ),
             allOf(
-                hasProperty("host", equalTo("kapacitor-1")),
+                hasProperty("host", equalTo("kapacitor-1.kapacitor")),
                 hasProperty("port", equalTo(9092))
             )
         )
@@ -103,7 +103,7 @@ public class KubernetesServiceEndpointPickerTest {
         allInstances,
         contains(
             allOf(
-                hasProperty("host", equalTo("kapacitor-1")),
+                hasProperty("host", equalTo("kapacitor-1.kapacitor")),
                 hasProperty("port", equalTo(9092))
             )
         )


### PR DESCRIPTION
# Resolves

Helps https://jira.rax.io/browse/SALUS-637

# What

Solves this error

```
nested exception is java.net.UnknownHostException: kapacitor-1
```

# How

Apparently headless service hostnames now need to be qualified by the service name, as discovered with some `exec` experimenting:

```
root@event-management-677bf4db-4fhgf:/# ping kapacitor-0
ping: unknown host
root@event-management-677bf4db-4fhgf:/# ping kapacitor-0.kapacitorsvc
PING kapacitor-0.kapacitorsvc.salus-development.svc.cluster.local (10.35.204.9): 56 data bytes
64 bytes from 10.35.204.9: icmp_seq=0 ttl=62 time=1.202 ms
```

In the discovery code, it now appends the service name to the endpoint's hostname.

## How to test

Existing unit tests were updated

cc @nicksunday 