### PR TITLE
Improves handling of kube watch API errors

### DIFF
--- a/src/main/java/com/rackspace/salus/event/discovery/DiscoveryServiceModule.java
+++ b/src/main/java/com/rackspace/salus/event/discovery/DiscoveryServiceModule.java
@@ -20,6 +20,7 @@ import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
@@ -30,10 +31,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class DiscoveryServiceModule {
 
   private final DiscoveryProperties properties;
+  private final ConfigurableApplicationContext applicationContext;
 
   @Autowired
-  public DiscoveryServiceModule(DiscoveryProperties properties) {
+  public DiscoveryServiceModule(DiscoveryProperties properties,
+                                ConfigurableApplicationContext applicationContext) {
     this.properties = properties;
+    this.applicationContext = applicationContext;
   }
 
   @SuppressWarnings("UnstableApiUsage")
@@ -48,7 +52,7 @@ public class DiscoveryServiceModule {
     } else if (properties.getKubernetesStrategy() != null
         && properties.getPortStrategy() == null) {
       return new KubernetesServiceEndpointPicker(properties.getKubernetesStrategy(), hashFunction,
-          eventEngineTaskExecutor()
+          eventEngineTaskExecutor(), applicationContext
       );
     } else {
       throw new IllegalStateException(

--- a/src/test/java/com/rackspace/salus/event/discovery/DiscoveryServiceModuleTest.java
+++ b/src/test/java/com/rackspace/salus/event/discovery/DiscoveryServiceModuleTest.java
@@ -22,8 +22,12 @@ import com.rackspace.salus.event.discovery.DiscoveryProperties.KubernetesStrateg
 import com.rackspace.salus.event.discovery.DiscoveryProperties.PortStrategy;
 import org.hamcrest.Matchers;
 import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.StaticApplicationContext;
 
 public class DiscoveryServiceModuleTest {
+
+  ConfigurableApplicationContext applicationContext = new StaticApplicationContext();
 
   @Test
   public void testPortStrategyConfigured() {
@@ -31,7 +35,7 @@ public class DiscoveryServiceModuleTest {
     DiscoveryProperties properties = new DiscoveryProperties();
     properties.setPortStrategy(portStrategy);
 
-    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties);
+    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties, applicationContext);
     final EventEnginePicker picker = discoveryServiceModule.eventEnginePicker();
 
     assertThat(picker, Matchers.instanceOf(PortStrategyPicker.class));
@@ -43,7 +47,7 @@ public class DiscoveryServiceModuleTest {
     DiscoveryProperties properties = new DiscoveryProperties();
     properties.setKubernetesStrategy(kubernetesStrategy);
 
-    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties);
+    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties, applicationContext);
     final EventEnginePicker picker = discoveryServiceModule.eventEnginePicker();
 
     assertThat(picker, Matchers.instanceOf(KubernetesServiceEndpointPicker.class));
@@ -57,7 +61,7 @@ public class DiscoveryServiceModuleTest {
     properties.setPortStrategy(portStrategy);
     properties.setKubernetesStrategy(kubernetesStrategy);
 
-    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties);
+    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties, applicationContext);
 
     discoveryServiceModule.eventEnginePicker(); // should fail
   }
@@ -66,7 +70,7 @@ public class DiscoveryServiceModuleTest {
   public void testNoneConfigured() {
     DiscoveryProperties properties = new DiscoveryProperties();
 
-    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties);
+    final DiscoveryServiceModule discoveryServiceModule = new DiscoveryServiceModule(properties, applicationContext);
 
     discoveryServiceModule.eventEnginePicker(); // should fail
   }

--- a/src/test/java/com/rackspace/salus/event/discovery/KubernetesServiceEndpointPickerTest.java
+++ b/src/test/java/com/rackspace/salus/event/discovery/KubernetesServiceEndpointPickerTest.java
@@ -38,11 +38,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.StaticApplicationContext;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.task.SyncTaskExecutor;
 import org.springframework.util.StreamUtils;
 
 public class KubernetesServiceEndpointPickerTest {
+  ConfigurableApplicationContext applicationContext = new StaticApplicationContext();
 
   public static final Type WATCH_ENDPOINTS_TYPE = new TypeToken<Response<V1Endpoints>>() {
   }.getType();
@@ -55,7 +58,8 @@ public class KubernetesServiceEndpointPickerTest {
     picker = new KubernetesServiceEndpointPicker(
         new KubernetesStrategy(),
         Hashing.murmur3_128(),
-        new SyncTaskExecutor()
+        new SyncTaskExecutor(),
+        applicationContext
     );
     jsonParser = new JSON();
   }


### PR DESCRIPTION
# What

In the staging cluster we were seeing warning logs like the following; however, it was still hard to diagnose what was going wrong:

```json
{
    "level": "WARN",
    "logger": "com.rackspace.salus.event.discovery.KubernetesServiceEndpointPicker",
    "throwable": "io.kubernetes.client.ApiException: Forbidden\n\tat io.kubernetes.client.util.Watch.createWatch(Watch.java:107)\n\tat com.rackspace.salus.event.discovery.KubernetesServiceEndpointPicker.createWatch(KubernetesServiceEndpointPicker.java:126)\n\tat com.rackspace.salus.event.discovery.KubernetesServiceEndpointPicker.watchEndpoint(KubernetesServiceEndpointPicker.java:108)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)\n\tat java.base/java.lang.Thread.run(Thread.java:834)\n",
    "thread": "eventEngine-1",
    "message": "Failed during endpoints watch",
    "@timestamp": "2019-11-25T19:32:25.000000000+00:00",
    "tag": "application.salus-event-engine-ingest"
  }
```

# How

Logs the response body of the API exception and shuts down the application. The recursive call to re-try the watch seemed a little dangerous especially without any kind of "retry delay".

The extra debug log when attempting to create the watch should help identity config mismatches.

## How to test

Existing unit tests should still work, but don't really exercise the original problem.