### PR TITLE
Removed qualifying/prefixing the account and used tenant wording

### DIFF
--- a/src/main/java/com/rackspace/salus/event/common/Tags.java
+++ b/src/main/java/com/rackspace/salus/event/common/Tags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Rackspace US, Inc.
+ * Copyright 2020 Rackspace US, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ public class Tags {
   public static final String RESOURCE_ID = qualify("resource_id");
   public static final String RESOURCE_LABEL = qualify("resource_label");
   public static final String MONITORING_SYSTEM = qualify("monitoring_system");
-  public static final String QUALIFIED_ACCOUNT = qualify("qualified_account");
+  public static final String TENANT = qualify("tenant");
 
   private static String qualify(String resourceId) {
     return applyNamespace(EVENT_ENGINE_TAGS, resourceId);


### PR DESCRIPTION
# Resolves

Part of https://jira.rax.io/browse/SALUS-927

# What

The event ingest and management code is being changed to no longer prefix the account/tenant ID with an account type. Instead, just the tenant as provided by Identity, will be used.

# How

Improve naming for consistency and just call it "tenant".

# How to test

<instructions for verifying the changes specific to this PR>

# Why

Ingest and Management unit tests will indirectly test this change.