### PR TITLE
Move kapacitor event from event-engine-management

### DIFF
--- a/src/main/java/com/rackspace/salus/event/lombok.config
+++ b/src/main/java/com/rackspace/salus/event/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.accessors.chain = true

--- a/src/main/java/com/rackspace/salus/event/model/kapacitor/DbRp.java
+++ b/src/main/java/com/rackspace/salus/event/model/kapacitor/DbRp.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.model.kapacitor;
+
+import lombok.Data;
+
+@Data
+public class DbRp {
+  String db;
+  String rp;
+}

--- a/src/main/java/com/rackspace/salus/event/model/kapacitor/KapacitorEvent.java
+++ b/src/main/java/com/rackspace/salus/event/model/kapacitor/KapacitorEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.model.kapacitor;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.Date;
+import java.util.List;
+import lombok.Data;
+
+@Data
+@JsonInclude(Include.NON_NULL)
+public class KapacitorEvent{
+    private String id;
+    private int duration;
+    private String previousLevel;
+    private EventData data;
+    private String level;
+    private boolean recoverable;
+    private String details;
+    private Date time;
+    private String message;
+
+    @Data
+    public static class EventData {
+        private List<SeriesItem> series;
+    }
+
+    @Data
+    public static class SeriesItem{
+        private String name;
+        private List<String> columns;
+        private List<Object> values;
+    }
+}

--- a/src/main/java/com/rackspace/salus/event/model/kapacitor/Task.java
+++ b/src/main/java/com/rackspace/salus/event/model/kapacitor/Task.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2020 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.model.kapacitor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Map;
+import lombok.Data;
+
+@Data
+public class Task {
+  String id;
+  Type type;
+  List<DbRp> dbrps;
+  String script;
+  Map<String, Var> vars;
+  Status status;
+  String error;
+  Stats stats;
+
+  public enum Type {
+    stream
+  }
+
+  public enum Status {
+    enabled, disabled
+  }
+
+  @Data
+  public static class Stats {
+    @JsonProperty("task-stats")
+    Map<String, Integer> taskStats;
+    @JsonProperty("node-stats")
+    Map<String, Map<String,Integer>> nodeStats;
+  }
+}

--- a/src/main/java/com/rackspace/salus/event/model/kapacitor/TaskList.java
+++ b/src/main/java/com/rackspace/salus/event/model/kapacitor/TaskList.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.model.kapacitor;
+
+import java.util.List;
+import lombok.Data;
+
+@Data
+public class TaskList {
+  List<Task> tasks;
+}

--- a/src/main/java/com/rackspace/salus/event/model/kapacitor/Var.java
+++ b/src/main/java/com/rackspace/salus/event/model/kapacitor/Var.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Rackspace US, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.rackspace.salus.event.model.kapacitor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Data;
+
+@Data @Builder
+public class Var {
+  Object value;
+  Type type;
+
+  public enum Type {
+    // can't use lowercase as identifier since those are Java keywords
+    @JsonProperty("bool")
+    BOOL,
+    @JsonProperty("int")
+    INT,
+    @JsonProperty("float")
+    FLOAT,
+    @JsonProperty("string")
+    STRING
+  }
+
+  public static Var from(Object value) {
+    final VarBuilder builder = Var.builder()
+        .value(value);
+    if (value instanceof Integer) {
+      builder.type(Type.INT);
+    } else if (value instanceof Float) {
+      builder.type(Type.FLOAT);
+    } else if (value instanceof Boolean) {
+      builder.type(Type.BOOL);
+    } else if (value instanceof String) {
+      builder.type(Type.STRING);
+    } else {
+      throw new IllegalArgumentException("Unable to handle value with type " + value.getClass());
+    }
+    return builder.build();
+  }
+}


### PR DESCRIPTION
`KapacitorEvent` will have to be used by the service that processes events.

Due to that it makes more sense having these objects in `common` which can be imported by any app that needs it.

I'll follow up by removing these from https://github.com/racker/salus-event-engine-management

